### PR TITLE
feat: UPGMA algorithm for phylogenetic tree construction

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,10 +19,6 @@ ChooseAlgorithm:
 	}
 	fmt.Scanln(&algorithmChoice)
 
-	fmt.Println()
-	fmt.Println()
-	fmt.Println()
-
 	switch algorithmChoice {
 	case 0:
 		alignment.Alignment()

--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/wlfp/bioinfo_algos/alignment"
+	"github.com/wlfp/bioinfo_algos/phylogeny"
 )
 
 func main() {
 
-	algorithmChoices := [...]string{"Global alignment"}
+	algorithmChoices := [...]string{"Global alignment", "UPGMA"}
 
 	var algorithmChoice int
 ChooseAlgorithm:
@@ -25,6 +26,8 @@ ChooseAlgorithm:
 	switch algorithmChoice {
 	case 0:
 		alignment.Alignment()
+	case 1:
+		phylogeny.UPGMA()
 	default:
 		fmt.Println("That algorithm wasn't recognised, try again?")
 		goto ChooseAlgorithm

--- a/phylogeny/trees.go
+++ b/phylogeny/trees.go
@@ -8,7 +8,6 @@ import (
 
 func (distanceMatrix distanceMatrix) String() string {
 	var builder strings.Builder
-	first := true
 	for index, cluster := range distanceMatrix.clusters {
 		if slices.Contains(distanceMatrix.deadClusterIndices, index) {
 			continue
@@ -16,14 +15,8 @@ func (distanceMatrix distanceMatrix) String() string {
 		if cluster.node == nil {
 			continue
 		}
-		if !first {
-			builder.WriteByte('\n')
-		}
+		builder.WriteByte('\n')
 		builder.WriteString(cluster.node.String())
-		first = false
-	}
-	if first {
-		return "<no active clusters>"
 	}
 	return builder.String()
 }

--- a/phylogeny/trees.go
+++ b/phylogeny/trees.go
@@ -1,0 +1,106 @@
+package phylogeny
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+func (distanceMatrix distanceMatrix) String() string {
+	var builder strings.Builder
+	first := true
+	for index, cluster := range distanceMatrix.clusters {
+		if slices.Contains(distanceMatrix.deadClusterIndices, index) {
+			continue
+		}
+		if cluster.node == nil {
+			continue
+		}
+		if !first {
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(cluster.node.String())
+		first = false
+	}
+	if first {
+		return "<no active clusters>"
+	}
+	return builder.String()
+}
+
+type treeNode struct {
+	name         string
+	left, right  *treeNode
+	branchLength float64
+	height       float64
+}
+
+func (node *treeNode) String() string {
+	if node == nil {
+		return ""
+	}
+	var builder strings.Builder
+	node.buildPrettyString(&builder, "", true, false)
+	return strings.TrimSuffix(builder.String(), "\n")
+}
+
+func (node *treeNode) label() string {
+	if node == nil {
+		return ""
+	}
+	return node.name + node.metricsSuffix()
+}
+
+func (node *treeNode) children() []*treeNode {
+	var result []*treeNode
+	if node.left != nil {
+		result = append(result, node.left)
+	}
+	if node.right != nil {
+		result = append(result, node.right)
+	}
+	return result
+}
+
+func (node *treeNode) metricsSuffix() string {
+	if node == nil {
+		return ""
+	}
+	var parts []string
+	if node.height != 0 {
+		parts = append(parts, fmt.Sprintf("h=%.2f", node.height))
+	}
+	if node.branchLength != 0 {
+		parts = append(parts, fmt.Sprintf("len=%.2f", node.branchLength))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " [" + strings.Join(parts, ", ") + "]"
+}
+
+func (node *treeNode) buildPrettyString(builder *strings.Builder, prefix string, isTail, hasParent bool) {
+	builder.WriteString(prefix)
+	if hasParent {
+		if isTail {
+			builder.WriteString("\\-- ")
+		} else {
+			builder.WriteString("+-- ")
+		}
+	}
+	builder.WriteString(node.label())
+	builder.WriteByte('\n')
+
+	children := node.children()
+	for index, child := range children {
+		childPrefix := prefix
+		if hasParent {
+			if isTail {
+				childPrefix += "    "
+			} else {
+				childPrefix += "|   "
+			}
+		}
+		child.buildPrettyString(builder, childPrefix, index == len(children)-1, true)
+	}
+}

--- a/phylogeny/upgma.go
+++ b/phylogeny/upgma.go
@@ -9,6 +9,7 @@ import (
 type cluster struct {
 	name string
 	size int
+	node *treeNode
 }
 
 type distanceMatrix struct {
@@ -42,6 +43,11 @@ func (distanceMatrix *distanceMatrix) mergeClosestClusters(closestClusters [2]in
 	var newCluster cluster
 	newCluster.name = distanceMatrix.clusters[closestClusters[0]].name + distanceMatrix.clusters[closestClusters[1]].name
 	newCluster.size = distanceMatrix.clusters[closestClusters[0]].size + distanceMatrix.clusters[closestClusters[1]].size
+	newCluster.node = &treeNode{
+		name:  newCluster.name,
+		left:  distanceMatrix.clusters[closestClusters[0]].node,
+		right: distanceMatrix.clusters[closestClusters[1]].node,
+	}
 	distanceMatrix.deadClusterIndices = append(distanceMatrix.deadClusterIndices, closestClusters[0])
 	distanceMatrix.deadClusterIndices = append(distanceMatrix.deadClusterIndices, closestClusters[1])
 	distanceMatrix.clusters = append(distanceMatrix.clusters, newCluster)
@@ -49,7 +55,6 @@ func (distanceMatrix *distanceMatrix) mergeClosestClusters(closestClusters [2]in
 	distanceMatrix.clusterSimilarities = append(distanceMatrix.clusterSimilarities, []float64{})
 
 	distanceMatrix.updateDistanceMatrix(closestClusters)
-	fmt.Println(distanceMatrix)
 }
 
 // memberIndices contains the two clusters that just combined.
@@ -81,12 +86,18 @@ func (distanceMatrix *distanceMatrix) upgma() {
 	for len(distanceMatrix.clusters)-len(distanceMatrix.deadClusterIndices) > 1 {
 		closestClusters := distanceMatrix.findClosestClusters()
 		distanceMatrix.mergeClosestClusters(closestClusters)
+		fmt.Println(distanceMatrix)
 	}
 }
 
 func UPGMA() {
 	var distanceMatrix distanceMatrix
-	distanceMatrix.clusters = []cluster{{name: "A", size: 1}, {name: "B", size: 1}, {name: "C", size: 1}, {name: "D", size: 1}}
+	distanceMatrix.clusters = []cluster{
+		{name: "A", size: 1, node: &treeNode{name: "A"}},
+		{name: "B", size: 1, node: &treeNode{name: "B"}},
+		{name: "C", size: 1, node: &treeNode{name: "C"}},
+		{name: "D", size: 1, node: &treeNode{name: "D"}},
+	}
 	distanceMatrix.clusterSimilarities = [][]float64{{2, 4, 6}, {4, 6}, {6}}
 	distanceMatrix.upgma()
 }

--- a/phylogeny/upgma.go
+++ b/phylogeny/upgma.go
@@ -1,6 +1,10 @@
 package phylogeny
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+	"slices"
+)
 
 type cluster struct {
 	name string
@@ -9,15 +13,22 @@ type cluster struct {
 
 type distanceMatrix struct {
 	clusters            []cluster
+	deadClusterIndices  []int
 	clusterSimilarities [][]float64
 }
 
 func (distanceMatrix *distanceMatrix) findClosestClusters() [2]int {
-	var minClusterDistance float64 = distanceMatrix.clusterSimilarities[0][1]
-	var closestClusterPair [2]int = [2]int{0, 1}
+	var minClusterDistance float64 = math.MaxFloat64
+	var closestClusterPair [2]int = [2]int{-1, -1}
 	for clusterOneIndex, clusterOneSimilarities := range distanceMatrix.clusterSimilarities {
+		if slices.Contains(distanceMatrix.deadClusterIndices, clusterOneIndex) {
+			continue
+		}
 		for otherClusterIndex, otherClusterSimilarity := range clusterOneSimilarities {
 			clusterTwoIndex := clusterOneIndex + 1 + otherClusterIndex
+			if slices.Contains(distanceMatrix.deadClusterIndices, clusterTwoIndex) {
+				continue
+			}
 			if otherClusterSimilarity < minClusterDistance {
 				minClusterDistance = otherClusterSimilarity
 				closestClusterPair = [2]int{clusterOneIndex, clusterTwoIndex}
@@ -27,9 +38,55 @@ func (distanceMatrix *distanceMatrix) findClosestClusters() [2]int {
 	return closestClusterPair
 }
 
+func (distanceMatrix *distanceMatrix) mergeClosestClusters(closestClusters [2]int) {
+	var newCluster cluster
+	newCluster.name = distanceMatrix.clusters[closestClusters[0]].name + distanceMatrix.clusters[closestClusters[1]].name
+	newCluster.size = distanceMatrix.clusters[closestClusters[0]].size + distanceMatrix.clusters[closestClusters[1]].size
+	distanceMatrix.deadClusterIndices = append(distanceMatrix.deadClusterIndices, closestClusters[0])
+	distanceMatrix.deadClusterIndices = append(distanceMatrix.deadClusterIndices, closestClusters[1])
+	distanceMatrix.clusters = append(distanceMatrix.clusters, newCluster)
+
+	distanceMatrix.clusterSimilarities = append(distanceMatrix.clusterSimilarities, []float64{})
+
+	distanceMatrix.updateDistanceMatrix(closestClusters)
+	fmt.Println(distanceMatrix)
+}
+
+// memberIndices contains the two clusters that just combined.
+func (distanceMatrix *distanceMatrix) updateDistanceMatrix(memberIndices [2]int) {
+	for clusterSimilaritiesIndex := range distanceMatrix.clusterSimilarities {
+		if slices.Contains(distanceMatrix.deadClusterIndices, clusterSimilaritiesIndex) {
+			continue
+		}
+		distanceMatrix.clusterSimilarities[clusterSimilaritiesIndex] = append(distanceMatrix.clusterSimilarities[clusterSimilaritiesIndex], distanceMatrix.computeNewClusterAverageDistance(memberIndices[0], memberIndices[1], clusterSimilaritiesIndex))
+	}
+}
+
+func (distanceMatrix *distanceMatrix) computeNewClusterAverageDistance(clusterOneIndex, clusterTwoIndex, oldClusterIndex int) float64 {
+	var similarityToOne, similarityToTwo float64
+	if clusterOneIndex < oldClusterIndex {
+		similarityToOne = distanceMatrix.clusterSimilarities[clusterOneIndex][oldClusterIndex-clusterOneIndex-1]
+	} else {
+		similarityToOne = distanceMatrix.clusterSimilarities[oldClusterIndex][clusterOneIndex-oldClusterIndex-1]
+	}
+	if clusterTwoIndex < oldClusterIndex {
+		similarityToTwo = distanceMatrix.clusterSimilarities[clusterTwoIndex][oldClusterIndex-clusterTwoIndex-1]
+	} else {
+		similarityToTwo = distanceMatrix.clusterSimilarities[oldClusterIndex][clusterTwoIndex-oldClusterIndex-1]
+	}
+	return (similarityToOne + similarityToTwo) / float64(distanceMatrix.clusters[clusterOneIndex].size+distanceMatrix.clusters[clusterTwoIndex].size)
+}
+
+func (distanceMatrix *distanceMatrix) upgma() {
+	for len(distanceMatrix.clusters)-len(distanceMatrix.deadClusterIndices) > 1 {
+		closestClusters := distanceMatrix.findClosestClusters()
+		distanceMatrix.mergeClosestClusters(closestClusters)
+	}
+}
+
 func UPGMA() {
 	var distanceMatrix distanceMatrix
 	distanceMatrix.clusters = []cluster{{name: "A", size: 1}, {name: "B", size: 1}, {name: "C", size: 1}, {name: "D", size: 1}}
 	distanceMatrix.clusterSimilarities = [][]float64{{2, 4, 6}, {4, 6}, {6}}
-	fmt.Println(distanceMatrix.findClosestClusters())
+	distanceMatrix.upgma()
 }

--- a/phylogeny/upgma.go
+++ b/phylogeny/upgma.go
@@ -1,0 +1,35 @@
+package phylogeny
+
+import "fmt"
+
+type cluster struct {
+	name string
+	size int
+}
+
+type distanceMatrix struct {
+	clusters            []cluster
+	clusterSimilarities [][]float64
+}
+
+func (distanceMatrix *distanceMatrix) findClosestClusters() [2]int {
+	var minClusterDistance float64 = distanceMatrix.clusterSimilarities[0][1]
+	var closestClusterPair [2]int = [2]int{0, 1}
+	for clusterOneIndex, clusterOneSimilarities := range distanceMatrix.clusterSimilarities {
+		for otherClusterIndex, otherClusterSimilarity := range clusterOneSimilarities {
+			clusterTwoIndex := clusterOneIndex + 1 + otherClusterIndex
+			if otherClusterSimilarity < minClusterDistance {
+				minClusterDistance = otherClusterSimilarity
+				closestClusterPair = [2]int{clusterOneIndex, clusterTwoIndex}
+			}
+		}
+	}
+	return closestClusterPair
+}
+
+func UPGMA() {
+	var distanceMatrix distanceMatrix
+	distanceMatrix.clusters = []cluster{{name: "A", size: 1}, {name: "B", size: 1}, {name: "C", size: 1}, {name: "D", size: 1}}
+	distanceMatrix.clusterSimilarities = [][]float64{{2, 4, 6}, {4, 6}, {6}}
+	fmt.Println(distanceMatrix.findClosestClusters())
+}


### PR DESCRIPTION
Add an implementation of the UPGMA algorithm for phylogenetic tree construction.
Rather than 'deleting' items from the matrix once they have been merged into other clusters, this implementation maintains a list of `deadClusters` that are skipped by the algorithm.
Lookup into deadClusters is currently O(n), but since n is small this is OK. It could be made faster with a `map[int]struct{}`.

This PR also includes pretty printing methods on UPGMA trees, although the majority of that code is courtesy of Codex, to save time.

A follow-up PR could also add a better entry point for the algorithm, rather than just running a hard-coded example.